### PR TITLE
Positioning in CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,16 +23,26 @@ jobs:
       with:
         version: latest
         
+    - uses: actions/cache@v2
+      id: vcpkg-cache
+      with:
+        path: vcpkg
+        key: ${{ runner.os }}-vcpkg
+        
     - name: Get vcpkg
+      if: steps.vcpkg-cache.outputs.cache-hit != 'true'
       run: git clone https://github.com/microsoft/vcpkg.git --depth 1
 
     - name: Bootstrap vcpkg
+      if: steps.vcpkg-cache.outputs.cache-hit != 'true'
       run: ./vcpkg/bootstrap-vcpkg.sh
 
     - name: Integrate vcpkg
+      if: steps.vcpkg-cache.outputs.cache-hit != 'true'
       run: ./vcpkg/vcpkg integrate install
       
     - name: Install dependencies
+      if: steps.vcpkg-cache.outputs.cache-hit != 'true'
       run: ./vcpkg/vcpkg install boost-iostreams boost-timer boost-system gtest benchmark fftw3[threads] tbb
       
     - name: Install IPP

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,10 +1,6 @@
 name: CMake
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: push
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,6 +24,12 @@ jobs:
         version: latest
         
     - uses: actions/cache@v2
+      id: positioning_signal_cache
+      with:
+        path: ugsdr/data/GPSdata-DiscreteComponents-fs38_192-if9_55.bin
+        key: ${{ runner.os }}-positioning_signal_cache
+        
+    - uses: actions/cache@v2
       id: vcpkg-cache
       with:
         path: vcpkg

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ CMakeSettings.json
 /external/RTKLIB/
 
 /research/*
+GPSdata-DiscreteComponents-fs38_192-if9_55.bin

--- a/src/measurements/measurement_engine.hpp
+++ b/src/measurements/measurement_engine.hpp
@@ -124,7 +124,7 @@ namespace ugsdr {
 				throw std::runtime_error("Unexpected nullptr");
 			rtklib_helpers::FillRinexCodes(rnxopt, available_signals);
 
-			auto rinex_obs = std::unique_ptr<FILE, int(*)(FILE*)>(fopen("../../../../research/ugsdr.obs", "w"), fclose);
+			auto rinex_obs = std::unique_ptr<FILE, int(*)(FILE*)>(fopen("ugsdr.obs", "w"), fclose);
 
 			outrnxobsh(rinex_obs.get(), rnxopt, nav.get());
 
@@ -140,7 +140,7 @@ namespace ugsdr {
 			if (!rnxopt)
 				throw std::runtime_error("Unexpected nullptr");
 
-			auto rinex_nav = std::unique_ptr<FILE, int(*)(FILE*)>(fopen("../../../../research/ugsdr.nav", "w"), fclose);
+			auto rinex_nav = std::unique_ptr<FILE, int(*)(FILE*)>(fopen("ugsdr.nav", "w"), fclose);
 
 			outrnxnavh(rinex_nav.get(), rnxopt, nav.get());
 			for (std::size_t i = 0; i < nav->n; ++i)

--- a/src/positioning/standalone_rtklib.hpp
+++ b/src/positioning/standalone_rtklib.hpp
@@ -31,7 +31,7 @@ namespace ugsdr {
 			}
 
 
-			return 0;
+			return std::make_tuple(sol->rr[0], sol->rr[1], sol->rr[2], sol->dtr[0]);
 		}
 
 	public:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,12 @@ if (${OpenMP_FOUND})
 endif()
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 20)
+file(DOWNLOAD 
+		https://www.dropbox.com/s/gn44cfbrqjnkhfw/GPSdata-DiscreteComponents-fs38_192-if9_55.bin
+		${CMAKE_CURRENT_LIST_DIR}/../data/GPSdata-DiscreteComponents-fs38_192-if9_55.bin 
+		SHOW_PROGRESS
+		EXPECTED_MD5 f5b0f32d0f97b23060d62ea3b5dc86b2
+)
 
 enable_testing()
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -663,7 +663,6 @@ namespace integration_tests {
 			tracker.Track(signal_parameters.GetNumberOfEpochs());
 
 			auto measurement_engine = ugsdr::MeasurementEngine(tracker.GetTrackingParameters());
-			measurement_engine.WriteRinex(1000);
 			auto positioning_engine = ugsdr::StandaloneRtklib(measurement_engine);
 
 			auto reference_position = std::vector{ -1288157, -4720787, 4079721};

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -34,6 +34,12 @@
 #include "../src/dfe/dfe.hpp"
 #include "../src/acquisition/fse.hpp"
 
+#include "../src/tracking/tracker.hpp"
+
+#include "../src/measurements/measurement_engine.hpp"
+
+#include "../src/positioning/standalone_rtklib.hpp"
+
 #include <type_traits>
 
 namespace basic_tests {
@@ -632,4 +638,46 @@ namespace integration_tests {
 			TestAcquisition<typename TestFixture::Type>(ugsdr::FileType::Nt1065GrabberSecond, ugsdr::Signal::GlonassCivilFdma_L1);
 		}
 	}
+
+	namespace PositioningTests {
+		template <typename T>
+		class PositioningTest : public testing::Test {
+		public:
+			using Type = T;
+		};
+		using PositioningTypes = ::testing::Types<float, double>;
+		TYPED_TEST_SUITE(PositioningTest, PositioningTypes);
+
+		
+		TYPED_TEST(PositioningTest, GPSdata_DiscreteComponents) {
+			auto signal_parameters = ugsdr::SignalParametersBase<float>(SIGNAL_DATA_PATH + 
+				std::string("GPSdata-DiscreteComponents-fs38_192-if9_55.bin"), 
+				ugsdr::FileType::Real_8, 1575.42e6 + 9.55e6, 38.192e6);
+			auto digital_frontend = ugsdr::DigitalFrontend(
+				MakeChannel(signal_parameters, std::vector{ ugsdr::Signal::GpsCoarseAcquisition_L1 }, signal_parameters.GetSamplingRate())
+			);
+			auto fse = ugsdr::FastSearchEngineBase(digital_frontend, 5e3, 200);
+			auto acquisition_results = fse.Process();
+			ASSERT_FALSE(acquisition_results.empty());
+			auto tracker = ugsdr::Tracker(digital_frontend, acquisition_results);
+			tracker.Track(signal_parameters.GetNumberOfEpochs());
+
+			auto measurement_engine = ugsdr::MeasurementEngine(tracker.GetTrackingParameters());
+			measurement_engine.WriteRinex(1000);
+			auto positioning_engine = ugsdr::StandaloneRtklib(measurement_engine);
+
+			auto reference_position = std::vector{ -1288157, -4720787, 4079721};
+			auto pos_and_time = positioning_engine.EstimatePosition(0);
+			auto pos = std::vector{ std::get<0>(pos_and_time), std::get<1>(pos_and_time), std::get<2>(pos_and_time)};
+
+			for (std::size_t i = 0; i < pos.size(); ++i)
+				pos[i] -= reference_position[i];
+			auto offset = std::accumulate(pos.begin(), pos.end(), 0.0, [](const auto& sum, const auto& val) {
+				return sum + val * val;
+			});
+
+			ASSERT_LE(offset, 5);
+		}
+	}
+
 }


### PR DESCRIPTION
Enable positioning test in CI, with vcpkg and signal caching (up to 10GB for 7 days)